### PR TITLE
wordpress/mysql.yaml 에 있는 오타 수정 (wrong indentation)

### DIFF
--- a/wordpress/mysql.yaml
+++ b/wordpress/mysql.yaml
@@ -51,15 +51,15 @@ spec:
             secretKeyRef:
               name: mysql-pass
               key: password.txt
-          ports:
-          - containerPort: 3306
-            name: mysql
-          resources:
-            requests:
-              cpu: 50m
-          volumeMounts:
-          - name: mysql-local-storage
-            mountPath: /var/lib/mysql
+        ports:
+        - containerPort: 3306
+          name: mysql
+        resources:
+          requests:
+            cpu: 50m
+        volumeMounts:
+        - name: mysql-local-storage
+          mountPath: /var/lib/mysql
       volumes:
       - name: mysql-local-storage
         persistentVolumeClaim:


### PR DESCRIPTION
wordpress 실습 자료 directory 에 있는 mysql.yaml 에서 잘못된 indentation 으로 인해 kubectl create 시 오류가 발생합니다.
본 커밋은 이를 수정합니다.